### PR TITLE
More correctly parse note velocity and pitch for NBS format

### DIFF
--- a/src/main/java/com/github/hhhzzzsss/songplayer/CommandProcessor.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/CommandProcessor.java
@@ -1696,7 +1696,7 @@ public class CommandProcessor {
 			}
 			Song song = new Song("test_song");
 			for (int i=0; i<400; i++) {
-				song.add(new Note(i, i*50, (byte) 127));
+				song.add(new Note(i, i*50, (byte) 127, (short) 0));
 			}
 			song.length = 400*50;
 			SongHandler.getInstance().setSong(song);

--- a/src/main/java/com/github/hhhzzzsss/songplayer/SongPlayer.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/SongPlayer.java
@@ -47,8 +47,6 @@ public class SongPlayer implements ModInitializer {
 	public static boolean recordingActive = false;
 	public static boolean recordingPaused = false;
 	public static int recordingtick = 0;
-	public static double[] pitchGlobal = { //used for /playsound
-		0.5, 0.529732, 0.561231, 0.594604, 0.629961, 0.66742, 0.707107, 0.749154, 0.793701, 0.840896, 0.890899, 0.943874, 1.0, 1.059463, 1.122462, 1.189207, 1.259921, 1.33484, 1.414214, 1.498307, 1.587401, 1.681793, 1.781797, 1.887749, 2.0};
 
 	public static String[] instrumentList = {"Harp", "Base Drum", "Snare", "Hat", "Bass", "Flute", "Bell", "Guitar", "Chime", "Xylophone", "Iron Xylophone", "Cow Bell", "Didgeridoo", "Bit", "Banjo", "Pling"};
 

--- a/src/main/java/com/github/hhhzzzsss/songplayer/Util.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/Util.java
@@ -330,7 +330,7 @@ public class Util {
         try {
             SongPlayer.creativeCommand = ModProperties.getInstance().getConfig().getProperty("creativeCommand", "gamemode creative");
             SongPlayer.survivalCommand = ModProperties.getInstance().getConfig().getProperty("survivalCommand", "gamemode survival");
-            SongPlayer.playSoundCommand = ModProperties.getInstance().getConfig().getProperty("playSoundCommand", "execute at @a run playsound minecraft:block.note_block.{type} record @p ~ ~30000000 ~ 300000000 {pitch} 1");
+            SongPlayer.playSoundCommand = ModProperties.getInstance().getConfig().getProperty("playSoundCommand", "execute as @a at @s positioned ^{panning} ^ ^ run playsound minecraft:block.note_block.{type} record @s ~ ~ ~ {volume} {pitch}");
             SongPlayer.stageType = ModProperties.getInstance().getConfig().getProperty("stageType", "default");
             SongPlayer.showProgressCommand = ModProperties.getInstance().getConfig().getProperty("showProgressCommand",
                     "execute at @a unless entity @s run title @p actionbar [" +

--- a/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
@@ -542,13 +542,12 @@ public class SongHandler {
                 int instrument = note.noteId / 25;
                 int pitchID = (note.noteId % 25);
                 double pitch = Math.pow(2, (pitchID + note.pitchCorrection/100.0 - 12) / 12);
-                if (pitch > 2.0) pitch = 2.0;
-                if (pitch < 0.5) pitch = 0.5;
+                if (pitch < 0.5 || pitch > 2.0) continue;
                 String command;
                 if (!SongPlayer.parseVolume) {
                     volume = "1.0";
                 }
-                command = SongPlayer.playSoundCommand.replace("{type}", instrumentNames[instrument]).replace("{volume}", String.valueOf(volume)).replace("{pitch}", Double.toString(pitch));
+                command = SongPlayer.playSoundCommand.replace("{type}", instrumentNames[instrument]).replace("{volume}", String.valueOf(volume)).replace("{pitch}", Double.toString(pitch)).replace("{panning}", String.valueOf((note.panning-100)/100.0*2));
                 if (SongPlayer.includeCommandBlocks) {
                     Util.sendCommandWithCommandblocks(command);
                 } else {

--- a/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
@@ -541,7 +541,7 @@ public class SongHandler {
                 String[] instrumentNames = {"harp", "basedrum", "snare", "hat", "bass", "flute", "bell", "guitar", "chime", "xylophone", "iron_xylophone", "cow_bell", "didgeridoo", "bit", "banjo", "pling"};
                 int instrument = note.noteId / 25;
                 int pitchID = (note.noteId % 25);
-                double pitch = SongPlayer.pitchGlobal[pitchID];
+                double pitch = Math.pow(2, (pitchID + note.pitchCorrection/100.0 - 12) / 12);
                 if (pitch > 2.0) pitch = 2.0;
                 if (pitch < 0.5) pitch = 0.5;
                 String command;
@@ -556,9 +556,9 @@ public class SongHandler {
                 }
             } else { //play client-side
                 if (SongPlayer.parseVolume) {
-                    player.playSound(soundlist[note.noteId / 25], SoundCategory.RECORDS, volfloat, (float) SongPlayer.pitchGlobal[(note.noteId % 25)]);
+                    player.playSound(soundlist[note.noteId / 25], SoundCategory.RECORDS, volfloat, (float) Math.pow(2, (note.noteId % 25 + note.pitchCorrection/100.0 - 12) / 12));
                 } else {
-                    world.playSound(Util.playerPosX, player.getY() + 3000000, Util.playerPosZ, soundlist[note.noteId / 25], SoundCategory.RECORDS, 30000000, (float) SongPlayer.pitchGlobal[(note.noteId % 25)], false);
+                    world.playSound(Util.playerPosX, player.getY() + 3000000, Util.playerPosZ, soundlist[note.noteId / 25], SoundCategory.RECORDS, 30000000, (float) Math.pow(2, (note.noteId % 25 + note.pitchCorrection/100.0 - 12) / 12), false);
                 }
             }
         }
@@ -626,9 +626,11 @@ public class SongHandler {
     }
 
     public void cleanup(boolean includePlaylist) {
-        if (!includePlaylist && Util.playlistSongs.size() > 0) {
-            return;
-        }
+//        if (!includePlaylist && Util.playlistSongs.size() > 0) {
+//            return;
+//        }
+//        System.out.println("Setting gamemode to Creative");
+        setCreativeIfNeeded();
         currentSong = null;
         songQueue.clear();
         stage = null;
@@ -636,6 +638,7 @@ public class SongHandler {
         Util.availableCommandBlocks.clear();
         Util.playlistSongs.clear();
         Util.currentPlaylist = "";
+        Util.playlistIndex = 0;
         Util.playlistIndex = 0;
         Util.loopPlaylist = false;
         SongPlayer.removeFakePlayer();

--- a/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/playing/SongHandler.java
@@ -625,11 +625,9 @@ public class SongHandler {
     }
 
     public void cleanup(boolean includePlaylist) {
-//        if (!includePlaylist && Util.playlistSongs.size() > 0) {
-//            return;
-//        }
-//        System.out.println("Setting gamemode to Creative");
-        setCreativeIfNeeded();
+        if (!includePlaylist && Util.playlistSongs.size() > 0) {
+            return;
+        }
         currentSong = null;
         songQueue.clear();
         stage = null;
@@ -637,7 +635,6 @@ public class SongHandler {
         Util.availableCommandBlocks.clear();
         Util.playlistSongs.clear();
         Util.currentPlaylist = "";
-        Util.playlistIndex = 0;
         Util.playlistIndex = 0;
         Util.loopPlaylist = false;
         SongPlayer.removeFakePlayer();

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/MidiConverter.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/MidiConverter.java
@@ -161,7 +161,7 @@ public class MidiConverter {
 		int noteId = pitch + instrument.instrumentId*25;
 		long time = microTime / 1000L;
 
-		return new Note(noteId, time, volume);
+		return new Note(noteId, time, volume, (short) 0);
 	}
 
 	private static Note getMidiPercussionNote(int midiPitch, long microTime, byte volume) {
@@ -169,7 +169,7 @@ public class MidiConverter {
 			int noteId = percussionMap.get(midiPitch);
 			long time = microTime / 1000L;
 
-			return new Note(noteId, time, volume);
+			return new Note(noteId, time, volume, (short) 0);
 		}
 		return null;
 	}

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/NBSConverter.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/NBSConverter.java
@@ -31,7 +31,7 @@ public class NBSConverter {
         public byte instrument;
         public byte key;
         public byte velocity = 100;
-        public byte panning = 127;
+        public int panning = 100;
         public short pitch = 0;
     }
 
@@ -105,7 +105,7 @@ public class NBSConverter {
                 note.key = buffer.get();
                 if (format >= 4) {
                     note.velocity = buffer.get();
-                    note.panning = buffer.get();
+                    note.panning = buffer.get() & 0xff;
                     note.pitch = buffer.getShort();
                 }
                 nbsNotes.add(note);
@@ -151,7 +151,7 @@ public class NBSConverter {
             }
             int pitch = note.key-33;
             int noteId = pitch + instrument.instrumentId*25;
-            song.add(new Note(noteId, getMilliTime(note.tick, tempo), (byte) (note.velocity/100.0*layerVolume/100.0*127), note.pitch));
+            song.add(new Note(noteId, getMilliTime(note.tick, tempo), (byte) (note.velocity/100.0*layerVolume/100.0*127), note.pitch, note.panning));
         }
 
         song.length = song.get(song.size()-1).time + 50;

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/NBSConverter.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/NBSConverter.java
@@ -30,7 +30,7 @@ public class NBSConverter {
         public short layer;
         public byte instrument;
         public byte key;
-        public byte velocity = 127;
+        public byte velocity = 100;
         public byte panning = 127;
         public short pitch = 0;
     }
@@ -145,13 +145,13 @@ public class NBSConverter {
 
             instrument = instrumentIndex[note.instrument];
 
-            byte layerVolume = 127; //is this variable assigned to the volume of the note? I didn't think nbs files had such a feature.
+            byte layerVolume = 100; //is this variable assigned to the volume of the note? I didn't think nbs files had such a feature.
             if (nbsLayers.size() > note.layer) {
                 layerVolume = nbsLayers.get(note.layer).volume;
             }
             int pitch = note.key-33;
             int noteId = pitch + instrument.instrumentId*25;
-            song.add(new Note(noteId, getMilliTime(note.tick, tempo), layerVolume));
+            song.add(new Note(noteId, getMilliTime(note.tick, tempo), (byte) (note.velocity/100.0*layerVolume/100.0*127), note.pitch));
         }
 
         song.length = song.get(song.size()-1).time + 50;

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/Note.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/Note.java
@@ -4,10 +4,12 @@ public class Note implements Comparable<Note> {
 	public int noteId;
 	public long time;
 	public byte volume;
-	public Note(int note, long time, byte volume) {
+	public short pitchCorrection;
+	public Note(int note, long time, byte volume, short pitchCorrection) {
 		this.noteId = note;
 		this.time = time;
 		this.volume = volume;
+		this.pitchCorrection = pitchCorrection;
 	}
 
 	@Override

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/Note.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/Note.java
@@ -5,11 +5,21 @@ public class Note implements Comparable<Note> {
 	public long time;
 	public byte volume;
 	public short pitchCorrection;
+	public int panning;
 	public Note(int note, long time, byte volume, short pitchCorrection) {
 		this.noteId = note;
 		this.time = time;
 		this.volume = volume;
 		this.pitchCorrection = pitchCorrection;
+        panning = 100;
+    }
+
+	public Note(int note, long time, byte volume, short pitchCorrection, int panning) {
+		this.noteId = note;
+		this.time = time;
+		this.volume = volume;
+		this.pitchCorrection = pitchCorrection;
+        this.panning = panning;
 	}
 
 	@Override

--- a/src/main/java/com/github/hhhzzzsss/songplayer/song/TxtConverter.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/song/TxtConverter.java
@@ -40,7 +40,7 @@ public class TxtConverter {
             if (tick > lasttick) {
                 lasttick = tick;
             }
-            song.add(new Note((instrument * 25 + pitch), tick * 50, (byte) 127));
+            song.add(new Note((instrument * 25 + pitch), tick * 50, (byte) 127, (short) 0));
         }
         song.length = lasttick * 50;
         return song;


### PR DESCRIPTION
Purpose is to make song playback in `command` and `client` mode more accurately reflect what you would hear in Note Block Studio
- changed note velocity range from 0 - 0.787 to 0 - 1
- take individual note velocity into account when calculating note volume
- replaced `pitchGlobal` with calculation that also respect `pitchCorrection`
- stripped out-of-range notes instead of rounding them to 0.5 or 2.0